### PR TITLE
fixes seed json format mistake

### DIFF
--- a/seed/dna/mongodb.json
+++ b/seed/dna/mongodb.json
@@ -1,5 +1,5 @@
 {
   "host": "{{{mongodb-host}}}",
   "name": "{{{mongodb-name}}}",
-  "port": {{{mongodb-port}}}
+  "port": "{{{mongodb-port}}}"
 }


### PR DESCRIPTION
This PR fixes a mistake in the `seed/dna/mongodb.json` seed file.

The mistake was causing error on `npx node-organic/organic-stem-mongodb-storage` execution.

```
apply stack upgrade /home/jazastry/.npm/_npx/4538/lib/node_modules/organic-stem-mongodb-storage-template/seed -> /home/jazastry/proj/olinuxino/aqualight-node
undefined:5
}
^

SyntaxError: Unexpected token } in JSON at position 59
    at JSON.parse (<anonymous>)
    at /home/jazastry/.npm/_npx/4538/lib/node_modules/organic-stem-mongodb-storage-template/node_modules/organic-stack-upgrade/lib/deep-merge-file.js:32:25
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:511:3)

```
